### PR TITLE
Allow deadstones to run in the browser while maintaining default Node compatibility and add ESM support

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,5 @@
-const wasm = require('./wasm')
+import {loadWasm} from './wasm.js'
+let fetchPath = null
 
 const parseBoard = data => ({
     newData: [].concat(...data),
@@ -6,47 +7,57 @@ const parseBoard = data => ({
 })
 
 const parseVertices = (indices, width) => [...indices].map(i => {
-    let x = i % width
+    const x = i % width
     return [x, (i - x) / width]
 })
 
 const parseGrid = (values, width) => {
     return [...Array(values.length / width)].map((_, y) => {
-        let start = y * width
+        const start = y * width
         return [...Array(width)].map((_, x) => values[start + x])
     })
 }
 
-exports.useFetch = function(path) {
-    wasm.fetchPath = path
-
-    return exports
+const useFetch = function(path) {
+    fetchPath = path
 }
 
-exports.guess = async function(data, {finished = false, iterations = 100} = {}) {
-    let {newData, width} = parseBoard(data)
-    let indices = (await wasm).guess(newData, width, finished, iterations, Date.now())
+const guess = async function(data, {finished = false, iterations = 100} = {}) {
+    const wasm = await loadWasm(fetchPath)
+    const {newData, width} = parseBoard(data)
+    const indices = wasm.guess(newData, width, finished, iterations, Date.now())
 
     return parseVertices(indices, width)
-},
+}
 
-exports.playTillEnd = async function(data, sign) {
-    let {newData, width} = parseBoard(data)
-    let values = (await wasm).playTillEnd(newData, width, sign, Date.now())
-
-    return parseGrid(values, width)
-},
-
-exports.getProbabilityMap = async function(data, iterations) {
-    let {newData, width} = parseBoard(data)
-    let values = (await wasm).getProbabilityMap(newData, width, iterations, Date.now())
+const playTillEnd = async function(data, sign) {
+    const wasm = await loadWasm(fetchPath)
+    const {newData, width} = parseBoard(data)
+    const values = wasm.playTillEnd(newData, width, sign, Date.now())
 
     return parseGrid(values, width)
-},
+}
 
-exports.getFloatingStones = async function(data) {
-    let {newData, width} = parseBoard(data)
-    let indices = (await wasm).getFloatingStones(newData, width)
+const getProbabilityMap = async function(data, iterations) {
+    const wasm = await loadWasm(fetchPath)
+    const {newData, width} = parseBoard(data)
+    const values = wasm.getProbabilityMap(newData, width, iterations, Date.now())
+
+    return parseGrid(values, width)
+}
+
+const getFloatingStones = async function(data) {
+    const wasm = await loadWasm(fetchPath)
+    const {newData, width} = parseBoard(data)
+    const indices = wasm.getFloatingStones(newData, width)
 
     return parseVertices(indices, width)
+}
+
+export default {
+    useFetch,
+    guess,
+    playTillEnd,
+    getProbabilityMap,
+    getFloatingStones
 }

--- a/js/main.mjs
+++ b/js/main.mjs
@@ -1,4 +1,4 @@
-const {loadWasm} = require('./wasm.js')
+import {loadWasm} from './wasm.mjs'
 
 const parseBoard = data => ({
     newData: [].concat(...data),
@@ -18,11 +18,11 @@ const parseGrid = (values, width) => {
 }
 
 let fetchPath = null
-const useFetch = function(path) {
+export const useFetch = function(path) {
     fetchPath = path
 }
 
-const guess = async function(data, {finished = false, iterations = 100} = {}) {
+export const guess = async function(data, {finished = false, iterations = 100} = {}) {
     const wasm = await loadWasm(fetchPath)
     const {newData, width} = parseBoard(data)
     const indices = wasm.guess(newData, width, finished, iterations, Date.now())
@@ -30,7 +30,7 @@ const guess = async function(data, {finished = false, iterations = 100} = {}) {
     return parseVertices(indices, width)
 }
 
-const playTillEnd = async function(data, sign) {
+export const playTillEnd = async function(data, sign) {
     const wasm = await loadWasm(fetchPath)
     const {newData, width} = parseBoard(data)
     const values = wasm.playTillEnd(newData, width, sign, Date.now())
@@ -38,7 +38,7 @@ const playTillEnd = async function(data, sign) {
     return parseGrid(values, width)
 }
 
-const getProbabilityMap = async function(data, iterations) {
+export const getProbabilityMap = async function(data, iterations) {
     const wasm = await loadWasm(fetchPath)
     const {newData, width} = parseBoard(data)
     const values = wasm.getProbabilityMap(newData, width, iterations, Date.now())
@@ -46,7 +46,7 @@ const getProbabilityMap = async function(data, iterations) {
     return parseGrid(values, width)
 }
 
-const getFloatingStones = async function(data) {
+export const getFloatingStones = async function(data) {
     const wasm = await loadWasm(fetchPath)
     const {newData, width} = parseBoard(data)
     const indices = wasm.getFloatingStones(newData, width)
@@ -54,7 +54,7 @@ const getFloatingStones = async function(data) {
     return parseVertices(indices, width)
 }
 
-module.exports = {
+export default {
     useFetch,
     guess,
     playTillEnd,

--- a/js/wasm.js
+++ b/js/wasm.js
@@ -165,5 +165,5 @@ module.exports.loadWasm = async function (fetchPath) {
         wasm = await WebAssembly.instantiate(buffer, imports)
     }
 
-    return loadedWasm =make(wasm.instance.exports)
+    return loadedWasm = make(wasm.instance.exports)
 }

--- a/js/wasm.js
+++ b/js/wasm.js
@@ -127,13 +127,16 @@ const make = wasm => {
 
 const imports = {}
 
-let wasm
+let loadedWasm
 module.exports.loadWasm = async function (fetchPath) {
 
     //Already loaded
-    if (wasm) {
-        return wasm
+    if (loadedWasm) {
+        return loadedWasm
     }
+
+    //Instantiate
+    let wasm
 
     //Load using fetch
     if (fetchPath) {
@@ -162,5 +165,5 @@ module.exports.loadWasm = async function (fetchPath) {
         wasm = await WebAssembly.instantiate(buffer, imports)
     }
 
-    return make(wasm.instance.exports)
+    return loadedWasm =make(wasm.instance.exports)
 }

--- a/js/wasm.mjs
+++ b/js/wasm.mjs
@@ -128,7 +128,7 @@ const make = wasm => {
 const imports = {}
 
 let wasm
-module.exports.loadWasm = async function (fetchPath) {
+export const loadWasm = async (fetchPath) => {
 
     //Already loaded
     if (wasm) {

--- a/js/wasm.mjs
+++ b/js/wasm.mjs
@@ -127,13 +127,16 @@ const make = wasm => {
 
 const imports = {}
 
-let wasm
+let loadedWasm
 export const loadWasm = async (fetchPath) => {
 
     //Already loaded
-    if (wasm) {
-        return wasm
+    if (loadedWasm) {
+        return loadedWasm
     }
+
+    //Instantiate
+    let wasm
 
     //Load using fetch
     if (fetchPath) {
@@ -162,5 +165,5 @@ export const loadWasm = async (fetchPath) => {
         wasm = await WebAssembly.instantiate(buffer, imports)
     }
 
-    return make(wasm.instance.exports)
+    return loadedWasm = make(wasm.instance.exports)
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "2.1.2",
   "description": "Simple Monte Carlo functions to determine dead stones on a Go board.",
   "main": "./js/main.js",
+  "exports": {
+    ".": {
+      "require": "./js/main.js",
+      "import": "./js/main.mjs"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/SabakiHQ/deadstones.git"


### PR DESCRIPTION
This PR addresses issue #1 
(cc @heroboy)

The problem was that this library defaulted to trying to find the wasm file using the local file system, and was only using fetch as a fallback. Because this was happening immediately on import, there is no way to prevent this from erroring in the browser, even when using polyfills/shims for the Node modules.

The solution presented in this PR solves this by doing the following:
1. The `wasm.js` file no longer exports the `wasm` instance as the default export, instead it exposes a helper called `loadWasm`
2. This loader can be given a `fetchPath`. If given, the loader will attempt to use fetch first to load the wasm file.
3. If no `fetchPath` is given, it will fallback to to the local file system so that backwards compatibility and out-of-the box node support is maintained, as you preferred @yishn 
4. Once the `wasm` file has been loaded it is cached and returned upon subsequent calls to `loadWasm()`
5. The `main.js` file is updated to use the new `loadWasm()` helper

I've also included `.mjs` equivalent files for people using ESM modules, while preserving the CJS implementation for backwards compatibility.

This should be fully backwards compatible with the current version, but now no longer triggering errors when used in the browser.

It can now be used in the browser as follows:

```js
import {guess, useFetch} from '@sabaki/deadstones'
import wasm from '@/assets/wasm/deadstones_bg.wasm?url'

//Instruct deadstones to use fetch
useFetch(wasm)

//Guess dead stones
const dead = await guess(...)
```